### PR TITLE
IPN Callback - Removendo a dependência entre o módulo Pagcoin e a configuração PHP + Apache 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+nbproject

--- a/app/code/community/PagCoin/BTCPayment/controllers/PagCoinController.php
+++ b/app/code/community/PagCoin/BTCPayment/controllers/PagCoinController.php
@@ -1,53 +1,57 @@
 <?php
-class PagCoin_BTCPayment_PagCoinController extends Mage_Core_Controller_Front_Action
-{
-	public function  IPNAction()
-    {
-		$headers = apache_request_headers();
-	
-		if(!isset($headers["EnderecoPagCoin"]) || !isset($headers["AssinaturaPagCoin"])){
-			die("Header invalido.");
-		}
-		
-		$postdata = file_get_contents("php://input");
-		$apikey = Mage::helper('core')->decrypt(Mage::getStoreConfig('payment/BTCPayment/merchantkey'));
-		
-		$signature = hash_hmac('sha256', $headers["EnderecoPagCoin"].$postdata, $apikey);
-		
-		if($signature != $headers["AssinaturaPagCoin"]){
-			die("Assinatura não confere.");
-		}
-		
-		$fields = json_decode($postdata);
-		
-		if ($fields["statusPagamento"] == 'confirmado'){
-			$quote = Mage::getModel('sales/quote')->load($fields["idInterna"]);
-			$order_id = $quote->getReservedOrderId();
-			
-			$order = Mage::getModel('sales/order')->load($order_id, 'increment_id');
-			$payment = $order->getPayment();
-			
-			$this->_createInvoice($order);
-			$order->setState(Mage_Sales_Model_Order::STATE_NEW ,true,$msg,false);
-			$order->save();
-		}
-		
-		echo '200 OK';
+
+class PagCoin_BTCPayment_PagCoinController extends Mage_Core_Controller_Front_Action {
+
+    public function IPNAction() {
+        
+        $request = $this->getRequest(); //get zend Request - fix apache_request_headers() dependency;
+        $enderecoPagCoin = $request->getHeader('EnderecoPagCoin');
+        $assinaturaPagCoin = $request->getHeader('AssinaturaPagCoin');
+
+        if (empty($enderecoPagCoin) || empty($assinaturaPagCoin)) {
+            die("Header invalido.");
+        }
+
+        $postdata = file_get_contents("php://input");
+        $apikey = Mage::helper('core')->decrypt(Mage::getStoreConfig('payment/BTCPayment/merchantkey'));
+
+        $signature = hash_hmac('sha256', $enderecoPagCoin . $postdata, $apikey);
+
+        if ($signature != $assinaturaPagCoin) {
+            die("Assinatura não confere.");
+        }
+
+        $fields = json_decode($postdata);
+
+        if ($fields["statusPagamento"] == 'confirmado') {
+            $quote = Mage::getModel('sales/quote')->load($fields["idInterna"]);
+            $order_id = $quote->getReservedOrderId();
+
+            $order = Mage::getModel('sales/order')->load($order_id, 'increment_id');
+            $payment = $order->getPayment();
+
+            $this->_createInvoice($order);
+            $order->setState(Mage_Sales_Model_Order::STATE_NEW, true, $msg, false);
+            $order->save();
+        }
+
+        echo '200 OK';
     }
-	
-	protected function _createInvoice($orderObj)
-    {
+
+    protected function _createInvoice($orderObj) {
         if (!$orderObj->canInvoice()) {
             return false;
         }
         $invoice = $orderObj->prepareInvoice();
         $invoice->register();
-        if($invoice->canCapture()){
+        if ($invoice->canCapture()) {
             $invoice->capture();
         }
         $invoice->save();
         $orderObj->addRelatedObject($invoice);
         return $invoice;
     }
+
 }
+
 ?>

--- a/app/code/community/PagCoin/BTCPayment/controllers/PagCoinController.php
+++ b/app/code/community/PagCoin/BTCPayment/controllers/PagCoinController.php
@@ -54,4 +54,3 @@ class PagCoin_BTCPayment_PagCoinController extends Mage_Core_Controller_Front_Ac
 
 }
 
-?>


### PR DESCRIPTION
O controlador  PagCoin_BTCPayment_PagCoinController utiliza a função apache_request_headers.
http://php.net/manual/pt_BR/function.apache-request-headers.php

Conforme a documentação do PHP esta função só está disponível quando o PHP está rodando como módulo do apache.

Configurações como PHP-FPM + NGINX não funcionam da maneira que está.

Para resolver o problema bastou utilizar as funções do objeto Request do próprio magento.

``` PHP
        // $headers = apache_request_headers();// esta linha foi removida
        $request = $this->getRequest(); 
        $enderecoPagCoin = $request->getHeader('EnderecoPagCoin');
        $assinaturaPagCoin = $request->getHeader('AssinaturaPagCoin');
```
